### PR TITLE
Added Options Panel and Question Limit 

### DIFF
--- a/TestFormatter/Models/Exam.cs
+++ b/TestFormatter/Models/Exam.cs
@@ -19,8 +19,8 @@ namespace TestFormatter.Models
         public bool IncludeSectionField { get; set; }
         public bool IncludeGradeField { get; set; }
 
-        public int IncludeNumberOfQuestionsField { get; set; }
-        public int IncludeNumberOfPointsField { get; set; }
+        public int QuestionLimit { get; set; } = 0; //Default limit (0 means no limit)
+        public int NumberOfPoints { get; set; }
 
         public void AddQuestion(Question question)
         {

--- a/TestFormatter/Pages/FormatterPage.xaml
+++ b/TestFormatter/Pages/FormatterPage.xaml
@@ -33,12 +33,12 @@
                         <!--" Number fields for each field option -->
                         <StackPanel Orientation="Horizontal" Margin="5">
                             <TextBlock Text="Number of Questions:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                             <TextBox Text="{Binding NumberOfQuestionsField, UpdateSourceTrigger=PropertyChanged}" Width="50" />
+                            <TextBox Text="{Binding QuestionLimit, UpdateSourceTrigger=PropertyChanged}" Width="40" />
                         </StackPanel>
 
                         <StackPanel Orientation="Horizontal" Margin="5">
                             <TextBlock Text="Total Points:" VerticalAlignment="Center" Margin="0,0,5,0"/>
-                            <TextBox Text="{Binding NumberOfPointsField, UpdateSourceTrigger=PropertyChanged}" Width="50" />
+                            <TextBox Text="{Binding QuestionLimit, UpdateSourceTrigger=PropertyChanged}" Width="40" />
                         </StackPanel>
 
                     </StackPanel>

--- a/TestFormatter/Pages/FormatterPage.xaml.cs
+++ b/TestFormatter/Pages/FormatterPage.xaml.cs
@@ -37,6 +37,16 @@ namespace TestFormatter.Pages
         //Add Questions code
         private void AddQuestionButton_Click(object sender, RoutedEventArgs e)
         {
+
+            if (currentExam.QuestionLimit > 0 && currentExam.Questions.Count >= currentExam.QuestionLimit)
+            {
+                MessageBox.Show($"You have reached the maximum number of questions ({currentExam.QuestionLimit}).",
+                                "Question Limit Reached",
+                                MessageBoxButton.OK,
+                                MessageBoxImage.Warning);
+                return; // Exit without adding a new question
+            }
+
             // Create a new FreeResponseQuestion by default
             var newQuestion = new Question();
             currentExam.AddQuestion(newQuestion);


### PR DESCRIPTION
Added options panel to the test creation page, connected this to the add questions button to limit the number of questions that can be added based on the entry in the Test Options panel. The name field, id field, data field, class field, section field, and grade field can be included using the test boxes. These were initialized as booleans. 