### PR TITLE
Added shuffle and arrow button functionality

### DIFF
--- a/TestFormatter/Controls/QuestionControl.xaml.cs
+++ b/TestFormatter/Controls/QuestionControl.xaml.cs
@@ -508,6 +508,8 @@ namespace TestFormatter.Controls
                         this.Question.Number = nextControl.Question.Number;
                         nextControl.Question.Number = tempNumber;
 
+                        ParentFormatterPage.swap_questions(currentIndex, false);
+
                         // Swap the QuestionControl positions
                         parentPanel.Children.RemoveAt(currentIndex + 1);
                         parentPanel.Children.Insert(currentIndex, nextControl);

--- a/TestFormatter/Controls/QuestionControl.xaml.cs
+++ b/TestFormatter/Controls/QuestionControl.xaml.cs
@@ -37,7 +37,7 @@ namespace TestFormatter.Controls
             DataContext = this;
         }
 
-        private void UpdateHeaderText()
+        public void UpdateHeaderText()
         {
             // Set HeaderText based on Question properties (e.g., number and type)
             HeaderText = $"Question #{question.Number}: {question.Type}";
@@ -516,4 +516,5 @@ namespace TestFormatter.Controls
             }
         }
     }
+
 }

--- a/TestFormatter/Controls/QuestionControl.xaml.cs
+++ b/TestFormatter/Controls/QuestionControl.xaml.cs
@@ -463,9 +463,57 @@ namespace TestFormatter.Controls
 
         private void UpArrowButton_Click(object sender, RoutedEventArgs e)
         {
+            var parentPanel = this.Parent as Panel;
+            if (parentPanel != null)
+            {
+                int currentIndex = parentPanel.Children.IndexOf(this);
+                if (currentIndex > 0) // Ensure it's not the first question
+                {
+                    // Swap the QuestionControl positions
+                    parentPanel.Children.RemoveAt(currentIndex);
+                    parentPanel.Children.Insert(currentIndex - 1, this);
+
+                    // Swap the numbers
+                    var previousControl = parentPanel.Children[currentIndex - 1] as QuestionControl;
+                    if (previousControl != null)
+                    {
+                        int tempNumber = this.Question.Number;
+                        this.Question.Number = previousControl.Question.Number;
+                        previousControl.Question.Number = tempNumber;
+
+                        // Update header texts
+                        this.UpdateHeaderText();
+                        previousControl.UpdateHeaderText();
+                    }
+                }
+            }
         }
         private void DownArrowButton_Click(object sender, RoutedEventArgs e)
         {
+            var parentPanel = this.Parent as Panel;
+            if (parentPanel != null)
+            {
+                int currentIndex = parentPanel.Children.IndexOf(this);
+                if (currentIndex < parentPanel.Children.Count - 1) // Ensure it's not the last question
+                {
+                    // Swap the QuestionControl positions
+                    var nextControl = parentPanel.Children[currentIndex + 1] as QuestionControl;
+                    parentPanel.Children.RemoveAt(currentIndex + 1);
+                    parentPanel.Children.Insert(currentIndex, nextControl);
+
+                    // Swap the numbers
+                    if (nextControl != null)
+                    {
+                        int tempNumber = this.Question.Number;
+                        this.Question.Number = nextControl.Question.Number;
+                        nextControl.Question.Number = tempNumber;
+
+                        // Update header texts
+                        this.UpdateHeaderText();
+                        nextControl.UpdateHeaderText();
+                    }
+                }
+            }
         }
     }
 }

--- a/TestFormatter/Controls/QuestionControl.xaml.cs
+++ b/TestFormatter/Controls/QuestionControl.xaml.cs
@@ -7,6 +7,7 @@ using TestFormatter.Models;
 using Microsoft.Win32;
 using System.Windows.Media.Imaging;
 using System.ComponentModel;
+using TestFormatter.Pages;
 
 namespace TestFormatter.Controls
 {
@@ -26,6 +27,7 @@ namespace TestFormatter.Controls
 
         //Header text property
         public string HeaderText { get; private set; } // Property for the header
+        public FormatterPage? ParentFormatterPage { get; set; }
 
         //Even handler so FormatterPage can modify Test class properly when big changes are done to the question (type change / deletion / Num change)
         public event EventHandler<Question> QuestionTypeChanged;
@@ -476,6 +478,8 @@ namespace TestFormatter.Controls
                         int tempNumber = this.Question.Number;
                         this.Question.Number = previousControl.Question.Number;
                         previousControl.Question.Number = tempNumber;
+
+                        ParentFormatterPage.swap_questions(currentIndex, true);
 
                         // Swap the QuestionControl positions
                         parentPanel.Children.RemoveAt(currentIndex);

--- a/TestFormatter/Models/Exam.cs
+++ b/TestFormatter/Models/Exam.cs
@@ -146,7 +146,7 @@ namespace TestFormatter.Models
                 for (int j = 0; j < Questions.Count; j++)
                 {
                     Question question = Questions[j];
-                    sb.AppendLine($"Question {j+1}");
+                    sb.AppendLine($"Question {question.Number}");
                     sb.AppendLine($"({question.Points} points) {question.QuestionText}");
                     if (question.Type == "Multiple Choice")
                     {

--- a/TestFormatter/Models/Exam.cs
+++ b/TestFormatter/Models/Exam.cs
@@ -143,9 +143,10 @@ namespace TestFormatter.Models
                     }
                 }
 
-                foreach (var question in Questions)
+                for (int j = 0; j < Questions.Count; j++)
                 {
-                    sb.AppendLine($"Question {question.Number}");
+                    Question question = Questions[j];
+                    sb.AppendLine($"Question {j+1}");
                     sb.AppendLine($"({question.Points} points) {question.QuestionText}");
                     if (question.Type == "Multiple Choice")
                     {
@@ -161,8 +162,27 @@ namespace TestFormatter.Models
                             sb.AppendLine("______________________________________________________________________________________");  // Placeholder line
                         }
                     }
-                    sb.AppendLine(new string('-', 40));  // Separator between questions
                 }
+                // foreach (var question in Questions)
+                // {
+                //     sb.AppendLine($"Question {question.Number}");
+                //     sb.AppendLine($"({question.Points} points) {question.QuestionText}");
+                //     if (question.Type == "Multiple Choice")
+                //     {
+                //         for (int i = 0; i < question.Options.Count; i++)
+                //         {
+                //             sb.AppendLine($"{i + 1}. {question.Options[i]}");
+                //         }
+                //     }
+                //     else
+                //     {
+                //         for (int i = 0; i < question.NumLines; i++)
+                //         {
+                //             sb.AppendLine("______________________________________________________________________________________");  // Placeholder line
+                //         }
+                //     }
+                //     sb.AppendLine(new string('-', 40));  // Separator between questions
+                // }
                 File.WriteAllText(filePath, sb.ToString());
         }
         // INotifyPropertyChanged implementation

--- a/TestFormatter/Pages/FormatterPage.xaml
+++ b/TestFormatter/Pages/FormatterPage.xaml
@@ -44,7 +44,7 @@
                     </StackPanel>
                 </Expander>
             </Border>
-
+    
             <!--Questions panel-->
             <ScrollViewer Width="Auto">
                 <StackPanel Name="QuestionsPanel">
@@ -67,6 +67,7 @@
                     <TextBlock Text="  " VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 </StackPanel>
                 <DockPanel HorizontalAlignment="Right">
+					<Button Content="Shuffle Questions" Click="ShuffleQuestionsButton_Click" />
                     <!--Save exam and return to it later-->
                     <Button Name="Save" Content="Save" Width="50" Click="Save_Click" Margin="10"/>
                     <!--Export exam to prefered format-->

--- a/TestFormatter/Pages/FormatterPage.xaml.cs
+++ b/TestFormatter/Pages/FormatterPage.xaml.cs
@@ -218,6 +218,10 @@ namespace TestFormatter.Pages
             {
                 QuestionsPanel.Children.Add(addQuestionButton);
             }
+
+
+            // Update both the question numbers and their headers
+            UpdateQuestionNumbers();
         }
 
     }

--- a/TestFormatter/Pages/FormatterPage.xaml.cs
+++ b/TestFormatter/Pages/FormatterPage.xaml.cs
@@ -68,7 +68,8 @@ namespace TestFormatter.Pages
             // Create a new instance of QuestionControl and set its Question property
             var questionControl = new QuestionControl
             {
-                Question = newQuestion
+                Question = newQuestion,
+                ParentFormatterPage = this
             };
 
             // Subscribe to the QuestionTypeChanged event
@@ -76,6 +77,9 @@ namespace TestFormatter.Pages
 
             // Subscribe to the QuestionDeleted event
             questionControl.QuestionDeleted += QuestionControl_QuestionDeleted;
+
+            // Subscribe to up and down arrow event
+            // questionControl.ArrowClicked += swap_questions;
 
             // Add the new QuestionControl to the Question Panel
             QuestionsPanel.Children.Insert(QuestionsPanel.Children.Count - 1, questionControl);
@@ -146,6 +150,22 @@ namespace TestFormatter.Pages
         protected virtual void OnPropertyChanged(string propertyName)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public void swap_questions(int currentIndex, bool up_arrow)
+        {
+            if (up_arrow)
+            {
+                Question tempQuestion = currentExam.Questions[currentIndex];
+                currentExam.Questions[currentIndex] = currentExam.Questions[currentIndex - 1];
+                currentExam.Questions[currentIndex - 1] = tempQuestion;
+            }
+            else
+            {
+                Question tempQuestion = currentExam.Questions[currentIndex + 1];
+                currentExam.Questions[currentIndex + 1] = currentExam.Questions[currentIndex];
+                currentExam.Questions[currentIndex] = tempQuestion;
+            }
         }
 
         private void ShuffleQuestionsButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Added shuffle and arrow button functionality. Major changes are found in the Questioncontrol and formatterPage. Added a button in the formatter page xaml for the shuffle button.  The updateHeaderText function in the Question control was changed from private to public so that the Update Question Numbers function can access it. Some other functions were implemented in the formatter page class to implement shuffle and the arrow buttons. 